### PR TITLE
Fix initial paging offset

### DIFF
--- a/app/src/main/java/com/igorapp/deckster/feature/home/viewmodel/HomeListViewModel.kt
+++ b/app/src/main/java/com/igorapp/deckster/feature/home/viewmodel/HomeListViewModel.kt
@@ -108,7 +108,9 @@ class HomeListViewModel @Inject constructor(
     }
 
     companion object {
-        var INITIAL_PAGE = 0
+        // Start paging at the same point as the SplashScreenViewModel to avoid
+        // reloading the first page again when requesting more data.
+        var INITIAL_PAGE = 1
         const val SIZE = 15
         const val GAME_FILTER = "game_status_filter"
     }

--- a/app/src/main/java/com/igorapp/deckster/feature/home/viewmodel/SearchListViewModel.kt
+++ b/app/src/main/java/com/igorapp/deckster/feature/home/viewmodel/SearchListViewModel.kt
@@ -64,7 +64,9 @@ class SearchListViewModel @Inject constructor(
 
 
     companion object {
-        var INITIAL_PAGE = 0
+        // Keep in sync with SplashScreenViewModel to prevent duplicate first
+        // page fetches when loading additional results.
+        var INITIAL_PAGE = 1
         const val SIZE = 20
         const val GAME_FILTER = "game_status_filter"
     }


### PR DESCRIPTION
## Summary
- align paging start for SearchListViewModel and HomeListViewModel with SplashScreenViewModel

## Testing
- `./gradlew test --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac56d0de0832ea4158003d33f9914