### PR TITLE
Add GameDao unit test

### DIFF
--- a/app/src/test/java/com/igorapp/deckster/data/GameDaoTest.kt
+++ b/app/src/test/java/com/igorapp/deckster/data/GameDaoTest.kt
@@ -1,0 +1,47 @@
+package com.igorapp.deckster.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.igorapp.deckster.model.Game
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GameDaoTest {
+
+    private lateinit var database: AppDatabase
+    private lateinit var gameDao: GameDao
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        database = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        gameDao = database.gameDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun insertAndRetrieveGames() = runBlocking {
+        val games = listOf(
+            Game("1", "Game One", "Playable", "Keyboard", "10h"),
+            Game("2", "Game Two", "Playable", "Keyboard", "20h")
+        )
+        gameDao.insertAll(games)
+
+        val fromDb = gameDao.getAll().first()
+        assertEquals(games.size, fromDb.size)
+        assertEquals(games.size, gameDao.getGamesCount())
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameDaoTest` using in-memory Room database

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac8225f04832eb7f64a96df906f31